### PR TITLE
Fix deprecation warning for dangerous query method

### DIFF
--- a/lib/saulabs/reportable/report.rb
+++ b/lib/saulabs/reportable/report.rb
@@ -122,7 +122,7 @@ module Saulabs
           table_name = ActiveRecord::Base.connection.quote_table_name(@klass.table_name)
           date_column = ActiveRecord::Base.connection.quote_column_name(@date_column.to_s)
           grouping = options[:grouping].to_sql("#{table_name}.#{date_column}")
-          order    = "#{grouping} ASC"
+          order    = Arel.sql("#{grouping} ASC")
 
           @klass.where(conditions).includes(options[:include]).distinct(options[:distinct]).
             group(grouping).order(order).limit(options[:limit]).


### PR DESCRIPTION
This warning happens when running unit tests for Print_Audits_Helper_Spec

DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "date_trunc('month', \"print_audits\".\"created_at\") ASC". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from read_data at ...vendor/bundle/ruby/2.5.0/bundler/gems/reportable-44ebda7bd3a6/lib/saulabs/reportable/report.rb:128)
